### PR TITLE
fix: publish canonical workflow_name in agent metadata

### DIFF
--- a/diagrid/agent/core/metadata/metadata.py
+++ b/diagrid/agent/core/metadata/metadata.py
@@ -55,6 +55,29 @@ def _is_etag_conflict(exc: Exception) -> bool:
     return "etag" in msg or "aborted" in msg
 
 
+def apply_workflow_name(
+    metadata: AgentMetadataSchema, framework: str, name: str
+) -> None:
+    """Publish the canonical workflow name into ``metadata.agent.metadata``.
+
+    The orchestrator reads ``agent.metadata['workflow_name']`` verbatim when
+    invoking this agent, so it must equal the name the runner registered the
+    workflow under. Setting it here makes our registration the single source of
+    truth instead of relying on the orchestrator re-deriving the name with
+    potentially different casing rules.
+
+    Mutates ``metadata`` in place (consistent with the surrounding registration
+    code) and preserves any existing ``agent.metadata`` keys.
+    """
+    # Imported lazily: importing the ``workflow`` package at module load would
+    # form a cycle (workflow -> runner -> metadata.mixins -> metadata).
+    from diagrid.agent.core.workflow.naming import build_workflow_name
+
+    if metadata.agent.metadata is None:
+        metadata.agent.metadata = {}
+    metadata.agent.metadata["workflow_name"] = build_workflow_name(framework, name)
+
+
 class AgentRegistryAdapter:
     @classmethod
     def create_from_stack(
@@ -159,6 +182,14 @@ class AgentRegistryAdapter:
                 _metadata.agent.metadata = {}
             if not _metadata.agent.metadata.get("state_store"):
                 _metadata.agent.metadata["state_store"] = self._state_store_name
+
+        # Publish the canonical workflow name so the orchestrator invokes the
+        # exact name our runner registered, instead of re-deriving it.
+        apply_workflow_name(
+            _metadata,
+            self._framework,
+            self._agent_name or _metadata.name,
+        )
 
         self._register(_metadata)
 

--- a/diagrid/agent/core/workflow/naming.py
+++ b/diagrid/agent/core/workflow/naming.py
@@ -68,3 +68,22 @@ def sanitize_agent_name(name: str) -> str:
     sanitized = re.sub(r"[<|\\/>]", "", sanitized)
 
     return sanitized or "unnamed_agent"
+
+
+def build_workflow_name(framework: str, name: str) -> str:
+    """Build the canonical Dapr workflow name for an agent.
+
+    Returns ``dapr.<framework>.<TitleCaseName>.workflow``. This is the single
+    source of truth for the workflow name used when registering a workflow and
+    when publishing the agent's ``workflow_name`` metadata, so the two can never
+    drift apart.
+
+    ``framework`` may be a ``SupportedFrameworks`` member (a ``StrEnum``) or a
+    plain string; ``str(...)`` handles both.
+
+    Examples::
+
+        build_workflow_name("LangGraph", "catering-coordinator")
+            -> "dapr.langgraph.CateringCoordinator.workflow"
+    """
+    return f"dapr.{str(framework).lower()}.{sanitize_agent_name(name)}.workflow"

--- a/diagrid/agent/core/workflow/runner.py
+++ b/diagrid/agent/core/workflow/runner.py
@@ -15,7 +15,7 @@ from dapr.ext.workflow import DaprWorkflowClient, WorkflowRuntime, WorkflowStatu
 from diagrid.agent.core.discovery import discover_components
 from diagrid.agent.core.metadata.mixins import AgentRegistryMixin
 from diagrid.agent.core.observability import resolve_observability_config
-from diagrid.agent.core.workflow.naming import sanitize_agent_name
+from diagrid.agent.core.workflow.naming import build_workflow_name
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +74,7 @@ class BaseWorkflowRunner(AgentRegistryMixin, ABC):
         The agent name is sanitized to TitleCase to match the convention
         used by dapr-agents (e.g. ``dapr.openai.CateringCoordinator.workflow``).
         """
-        return (
-            f"dapr.{self._framework.lower()}.{sanitize_agent_name(self._name)}.workflow"
-        )
+        return build_workflow_name(self._framework, self._name)
 
     # ------------------------------------------------------------------
     # Shared lifecycle

--- a/diagrid/agent/strands/durable_agent.py
+++ b/diagrid/agent/strands/durable_agent.py
@@ -71,7 +71,10 @@ class DurableAgent:
 
         Args:
             agent: The Strands Agent instance to make durable
-            name: Required name (produces ``dapr.strands.<name>.workflow``)
+            name: Required name. The workflow is registered under the canonical
+                ``dapr.strands.<TitleCaseName>.workflow`` — the name is
+                TitleCased/sanitized via ``build_workflow_name`` (e.g.
+                ``"schedule-planner"`` → ``dapr.strands.SchedulePlanner.workflow``).
         """
         self._agent = agent
         self._name = name

--- a/diagrid/agent/strands/durable_agent.py
+++ b/diagrid/agent/strands/durable_agent.py
@@ -19,6 +19,8 @@ from typing import Any, Generator
 from strands import Agent
 from strands.types.tools import ToolUse
 
+from diagrid.agent.core.workflow.naming import build_workflow_name, sanitize_agent_name
+
 logger = logging.getLogger(__name__)
 
 
@@ -73,7 +75,8 @@ class DurableAgent:
         """
         self._agent = agent
         self._name = name
-        self._workflow_name = f"dapr.strands.{name}.workflow"
+        self._sanitized_name = sanitize_agent_name(name)
+        self._workflow_name = build_workflow_name("strands", name)
 
         # Dapr components (initialized on first call)
         self._workflow_runtime: Any = None
@@ -365,10 +368,11 @@ class DurableAgent:
             agent_workflow, name=self._workflow_name
         )
         self._workflow_runtime.register_activity(
-            call_model_activity, name=f"dapr.strands.{self._name}.call_model"
+            call_model_activity, name=f"dapr.strands.{self._sanitized_name}.call_model"
         )
         self._workflow_runtime.register_activity(
-            execute_tool_activity, name=f"dapr.strands.{self._name}.execute_tool"
+            execute_tool_activity,
+            name=f"dapr.strands.{self._sanitized_name}.execute_tool",
         )
 
         # Store reference to workflow function for scheduling

--- a/diagrid/agent/strands/workflow.py
+++ b/diagrid/agent/strands/workflow.py
@@ -16,6 +16,8 @@ from typing import Any, Callable, Generator, TypeVar
 
 from strands import Agent
 
+from diagrid.agent.core.workflow.naming import build_workflow_name, sanitize_agent_name
+
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
@@ -70,10 +72,11 @@ class DaprAgentWorkflow:
     ) -> None:
         self.agent = agent
         self._name = name
-        self.workflow_name = f"dapr.strands.{name}.workflow"
+        sanitized = sanitize_agent_name(name)
+        self.workflow_name = build_workflow_name("strands", name)
         self._workflow_runtime: Any = None
         self._workflow_func: Any = None
-        self._activity_name = f"dapr.strands.{name}.run_agent"
+        self._activity_name = f"dapr.strands.{sanitized}.run_agent"
 
     def register(self, workflow_runtime: Any) -> None:
         """Register the agent workflow and activities with Dapr.

--- a/tests/agent/core/test_apply_workflow_name.py
+++ b/tests/agent/core/test_apply_workflow_name.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026-Present Diagrid Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Tests for publishing the canonical workflow_name into agent metadata."""
+
+from dapr_agents.agents.configs import AgentMetadata, AgentMetadataSchema
+
+from diagrid.agent.core.metadata.metadata import apply_workflow_name
+from diagrid.agent.core.types import SupportedFrameworks
+
+
+def _make_metadata(name: str, agent_metadata=None) -> AgentMetadataSchema:
+    return AgentMetadataSchema(
+        version="edge",
+        name=name,
+        registered_at="2026-01-01T00:00:00",
+        agent=AgentMetadata(
+            appid="app-1",
+            type="LangGraph",
+            orchestrator=False,
+            metadata=agent_metadata,
+        ),
+    )
+
+
+class TestApplyWorkflowName:
+    def test_sets_workflow_name_when_metadata_is_none(self):
+        meta = _make_metadata("catering-coordinator")
+        assert meta.agent.metadata is None
+
+        apply_workflow_name(meta, SupportedFrameworks.LANGGRAPH, "catering-coordinator")
+
+        assert meta.agent.metadata == {
+            "workflow_name": "dapr.langgraph.CateringCoordinator.workflow"
+        }
+
+    def test_preserves_existing_metadata_keys(self):
+        meta = _make_metadata(
+            "my-agent", agent_metadata={"framework": "langgraph", "state_store": "s1"}
+        )
+
+        apply_workflow_name(meta, "LangGraph", "my-agent")
+
+        assert meta.agent.metadata["framework"] == "langgraph"
+        assert meta.agent.metadata["state_store"] == "s1"
+        assert meta.agent.metadata["workflow_name"] == "dapr.langgraph.MyAgent.workflow"
+
+    def test_accepts_plain_string_framework(self):
+        meta = _make_metadata("venue-scout")
+
+        apply_workflow_name(meta, "strands", "venue-scout")
+
+        assert (
+            meta.agent.metadata["workflow_name"] == "dapr.strands.VenueScout.workflow"
+        )

--- a/tests/agent/core/test_strands_workflow_naming.py
+++ b/tests/agent/core/test_strands_workflow_naming.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2026-Present Diagrid Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+"""The Strands direct-construction paths must produce canonical workflow names."""
+
+from unittest import mock
+
+import pytest
+
+pytest.importorskip("strands")
+
+from diagrid.agent.strands.durable_agent import DurableAgent  # noqa: E402
+from diagrid.agent.strands.workflow import DaprAgentWorkflow  # noqa: E402
+
+
+def test_dapr_agent_workflow_name_is_title_cased():
+    wf = DaprAgentWorkflow(agent=mock.MagicMock(), name="venue-scout")
+    assert wf.workflow_name == "dapr.strands.VenueScout.workflow"
+    assert wf._activity_name == "dapr.strands.VenueScout.run_agent"
+
+
+def test_durable_agent_name_is_title_cased():
+    durable = DurableAgent(agent=mock.MagicMock(), name="catering-coordinator")
+    assert durable._workflow_name == "dapr.strands.CateringCoordinator.workflow"
+    assert durable._sanitized_name == "CateringCoordinator"

--- a/tests/agent/core/test_workflow_naming.py
+++ b/tests/agent/core/test_workflow_naming.py
@@ -5,7 +5,8 @@
 
 import pytest
 
-from diagrid.agent.core.workflow.naming import sanitize_agent_name
+from diagrid.agent.core.types import SupportedFrameworks
+from diagrid.agent.core.workflow.naming import build_workflow_name, sanitize_agent_name
 
 
 class TestSanitizeAgentName:
@@ -64,3 +65,39 @@ class TestSanitizeAgentName:
     def test_simple_names(self):
         assert sanitize_agent_name("sam") == "Sam"
         assert sanitize_agent_name("frodo") == "Frodo"
+
+
+class TestBuildWorkflowName:
+    """build_workflow_name should produce ``dapr.<framework>.<TitleCase>.workflow``."""
+
+    @pytest.mark.parametrize(
+        "framework,name,expected",
+        [
+            (
+                "LangGraph",
+                "catering-coordinator",
+                "dapr.langgraph.CateringCoordinator.workflow",
+            ),
+            ("strands", "my-agent", "dapr.strands.MyAgent.workflow"),
+            ("OpenAI", "get_user", "dapr.openai.GetUser.workflow"),
+            ("crewai", "Samwise Gamgee", "dapr.crewai.SamwiseGamgee.workflow"),
+        ],
+    )
+    def test_string_framework(self, framework, name, expected):
+        assert build_workflow_name(framework, name) == expected
+
+    def test_accepts_supported_frameworks_enum(self):
+        # StrEnum members must lower-case to the same prefix as plain strings.
+        assert (
+            build_workflow_name(SupportedFrameworks.OPENAI, "catering-coordinator")
+            == "dapr.openai.CateringCoordinator.workflow"
+        )
+        assert (
+            build_workflow_name(SupportedFrameworks.LANGGRAPH, "my-agent")
+            == "dapr.langgraph.MyAgent.workflow"
+        )
+
+    def test_empty_name_falls_back(self):
+        assert (
+            build_workflow_name("strands", "") == "dapr.strands.unnamed_agent.workflow"
+        )

--- a/tests/agent/core/test_workflow_runner.py
+++ b/tests/agent/core/test_workflow_runner.py
@@ -7,6 +7,7 @@ import asyncio
 from typing import Any, AsyncIterator
 from unittest import TestCase, mock
 
+from diagrid.agent.core.workflow.naming import build_workflow_name
 from diagrid.agent.core.workflow.runner import BaseWorkflowRunner
 
 
@@ -304,3 +305,19 @@ class TestConstructor(TestCase):
     ):
         ConcreteRunner(host="myhost", port="12345")
         mock_runtime_cls.assert_called_once_with(host="myhost", port="12345")
+
+
+@mock.patch("diagrid.agent.core.workflow.runner.DaprWorkflowClient")
+@mock.patch("diagrid.agent.core.workflow.runner.WorkflowRuntime")
+class TestWorkflowNameProperty(TestCase):
+    """workflow_name must delegate to build_workflow_name (single source of truth)."""
+
+    def test_delegates_to_builder(self, mock_runtime_cls, mock_client_cls):
+        runner = ConcreteRunner(name="catering-coordinator", framework="LangGraph")
+        self.assertEqual(
+            runner.workflow_name,
+            build_workflow_name("LangGraph", "catering-coordinator"),
+        )
+        self.assertEqual(
+            runner.workflow_name, "dapr.langgraph.CateringCoordinator.workflow"
+        )

--- a/tests/agent/strands_ext/test_workflow.py
+++ b/tests/agent/strands_ext/test_workflow.py
@@ -84,7 +84,9 @@ class TestDaprAgentWorkflow:
         workflow = DaprAgentWorkflow(agent=mock_agent, name="my_agent")
 
         assert workflow.agent is mock_agent
-        assert workflow.workflow_name == "dapr.strands.my_agent.workflow"
+        # Name is sanitized to canonical TitleCase so the registered workflow
+        # matches the workflow_name published to the agent registry.
+        assert workflow.workflow_name == "dapr.strands.MyAgent.workflow"
 
     def test_init_custom_name(self, mock_agent):
         """Test initialization with custom name."""
@@ -93,7 +95,7 @@ class TestDaprAgentWorkflow:
             name="test_workflow",
         )
 
-        assert workflow.workflow_name == "dapr.strands.test_workflow.workflow"
+        assert workflow.workflow_name == "dapr.strands.TestWorkflow.workflow"
 
     def test_register(self, mock_agent):
         """Test that register creates workflow and activity."""
@@ -123,7 +125,7 @@ class TestDaprAgentWorkflowDecorator:
         workflow = create_agent()
 
         assert isinstance(workflow, DaprAgentWorkflow)
-        assert workflow.workflow_name == "dapr.strands.decorated_workflow.workflow"
+        assert workflow.workflow_name == "dapr.strands.DecoratedWorkflow.workflow"
 
     def test_decorator_passes_args(self):
         """Test that decorator passes arguments to factory."""


### PR DESCRIPTION
This fix mimics the Dapr Agents canonical naming for the workflows to avoid 'actor not found'.