### PR TITLE
feat(plugins): scaffold the new module

### DIFF
--- a/diagrid/agent/core/plugins/__init__.py
+++ b/diagrid/agent/core/plugins/__init__.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2026-Present Diagrid Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Plugin SPI for Diagrid agents.
+
+The plugin system lets observability, authentication, OBO, HITL, and
+custom plugins intercept agent lifecycle events without modifying
+dapr-agents or python-ai's framework runners directly.
+
+Public API:
+    - Plugin: Protocol all plugins implement
+    - LifecycleEvent: enum of supported event names
+    - HookDecision: union of decision types
+      (Proceed / Skip / Mutate / RequireApproval / Deny)
+    - LifecycleContext: per-event context object passed to plugins
+    - PluginRegistry: chain dispatcher implementing dapr-agents'
+      LifecycleDispatcher Protocol
+"""
+
+from .spi import (
+    Plugin,
+    LifecycleEvent,
+    HookDecision,
+    Proceed,
+    Skip,
+    Mutate,
+    RequireApproval,
+    Deny,
+)
+from .context import (
+    LifecycleContext,
+    CallerIdentity,
+    CallTarget,
+)
+from .registry import PluginRegistry
+
+__all__ = [
+    "Plugin",
+    "LifecycleEvent",
+    "HookDecision",
+    "Proceed",
+    "Skip",
+    "Mutate",
+    "RequireApproval",
+    "Deny",
+    "LifecycleContext",
+    "CallerIdentity",
+    "CallTarget",
+    "PluginRegistry",
+]

--- a/diagrid/agent/core/plugins/context.py
+++ b/diagrid/agent/core/plugins/context.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2026-Present Diagrid Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Lifecycle context types passed into ``Plugin.on_event``.
+
+A ``LifecycleContext`` is the input to every plugin invocation.
+It carries the event name and the event-specific payload — caller
+identity, target, headers, and metadata.
+Plugins read what they need, optionally leave metadata for downstream
+plugins, and return a ``HookDecision``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+from diagrid.agent.core.plugins.spi import LifecycleEvent
+
+
+@dataclass
+class CallerIdentity:
+    """Verified caller identity for the current request.
+
+    Populated by the OAuth plugin on ``BEFORE_AGENT_INVOKE`` once the
+    sidecar ``/auth/verify`` call returns.
+    Downstream plugins read it through ``ctx.caller`` on later events in
+    the same request lifecycle.
+
+    Attributes:
+        subject: Verified ``sub`` claim, typically an email or user ID.
+        tenant: Tenant claim (e.g. ``org_id`` or ``tid``) per the IdP mapping.
+        scopes: OAuth scopes carried by the caller's JWT.
+        claims: Full verified claims, for plugins that need richer access.
+        issuer_id: Identifier of the IdP that issued the JWT.
+        is_agent: True when ``subject`` looks like an agent SPIFFE ID rather
+            than a human user, letting plugins tell sub-agent calls apart
+            from user calls.
+    """
+
+    subject: str
+    tenant: str
+    scopes: frozenset[str] = field(default_factory=frozenset)
+    claims: Dict[str, Any] = field(default_factory=dict)
+    issuer_id: str = ""
+    is_agent: bool = False
+
+
+@dataclass
+class CallTarget:
+    """Target of an outbound call.
+
+    Set for ``BEFORE_TOOL_CALL``, ``BEFORE_MCP_CALL``, and sub-agent
+    dispatch.
+
+    Attributes:
+        kind: One of ``"tool"``, ``"mcp"``, ``"subagent"``, or ``"llm"``.
+        name: Logical name, such as an MCP server or tool name.
+        source: Origin of the tool definition — ``"local"``, ``"mcp"``,
+            or ``"openapi"``.
+        audience: Target audience for token-bound auth, when applicable.
+        resource_indicators: RFC 8707 resource indicators.
+    """
+
+    kind: str
+    name: str
+    source: str = "local"
+    audience: Optional[str] = None
+    resource_indicators: frozenset[str] = field(default_factory=frozenset)
+
+
+@dataclass
+class LifecycleContext:
+    """Per-event context passed into ``Plugin.on_event``.
+
+    Attributes:
+        event: Which lifecycle event this is.
+        workflow_instance_id: Workflow instance ID, used for binding and audit.
+        agent_identity: The agent's own identity (SPIFFE ID, AppID, name).
+        caller: Verified caller identity, populated from
+            ``BEFORE_AGENT_INVOKE`` onward.
+        target: Outbound call target, populated for tool and MCP events.
+        caller_headers: Headers from the inbound request; upstream plugins
+            may scrub sensitive values.
+        request_id: Request correlation ID.
+        trace_id: W3C trace ID for correlation.
+        span_id: W3C span ID for correlation.
+        metadata: Plugin-to-plugin scratchpad, read and write.
+        payload: Event-specific payload such as LLM messages or tool args.
+    """
+
+    event: LifecycleEvent
+    workflow_instance_id: str
+    agent_identity: Dict[str, str]
+    caller: Optional[CallerIdentity] = None
+    target: Optional[CallTarget] = None
+    caller_headers: Dict[str, str] = field(default_factory=dict)
+    request_id: str = ""
+    trace_id: Optional[str] = None
+    span_id: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    payload: Dict[str, Any] = field(default_factory=dict)
+
+
+__all__ = [
+    "LifecycleContext",
+    "CallerIdentity",
+    "CallTarget",
+]

--- a/diagrid/agent/core/plugins/registry.py
+++ b/diagrid/agent/core/plugins/registry.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026-Present Diagrid Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+"""PluginRegistry — the chain dispatcher for the plugin system.
+
+This module scaffolds the class shape so other code can import and
+reference it.
+TODO(@sicoyle): The concrete dispatch, attach, and detach logic lands in a follow-on
+change; here those methods raise ``NotImplementedError``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+from diagrid.agent.core.plugins.spi import Plugin
+
+
+class PluginRegistry:
+    """Holds an ordered chain of plugins and dispatches lifecycle events.
+
+    Plugins run in ascending ``priority`` order, with registration order
+    breaking ties.
+    Once implemented, the first ``Deny``, ``Skip``, or ``RequireApproval``
+    short-circuits the chain while ``Mutate`` decisions accumulate.
+
+    The registry is meant to satisfy dapr-agents' ``LifecycleDispatcher``
+    Protocol (``attach``, ``detach``, ``dispatch``) so it can be passed as
+    ``DurableAgent(lifecycle_dispatcher=registry)``.
+    """
+
+    def __init__(self, plugins: Optional[Sequence[Plugin]] = None) -> None:
+        # Stable sort by priority alone preserves registration order for
+        # ties, which is the tie-break the chain relies on.
+        self._plugins: List[Plugin] = sorted(
+            plugins or [], key=lambda p: getattr(p, "priority", 100)
+        )
+
+    def attach(self, agent: Any) -> None:
+        """Configure each plugin against ``agent``; called at init time."""
+        raise NotImplementedError
+
+    def detach(self) -> None:
+        """Release per-plugin resources; called during cleanup."""
+        raise NotImplementedError
+
+    def dispatch(
+        self,
+        event_name: str,
+        context: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        """Run the plugin chain for a lifecycle event."""
+        raise NotImplementedError
+
+
+__all__ = ["PluginRegistry"]

--- a/diagrid/agent/core/plugins/registry.py
+++ b/diagrid/agent/core/plugins/registry.py
@@ -32,9 +32,7 @@ class PluginRegistry:
     def __init__(self, plugins: Optional[Sequence[Plugin]] = None) -> None:
         # Stable sort by priority alone preserves registration order for
         # ties, which is the tie-break the chain relies on.
-        self._plugins: List[Plugin] = sorted(
-            plugins or [], key=lambda p: getattr(p, "priority", 100)
-        )
+        self._plugins: List[Plugin] = sorted(plugins or [], key=lambda p: p.priority)
 
     def attach(self, agent: Any) -> None:
         """Configure each plugin against ``agent``; called at init time."""

--- a/diagrid/agent/core/plugins/spi.py
+++ b/diagrid/agent/core/plugins/spi.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026-Present Diagrid Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Core SPI types for the plugin system.
+
+The ``Plugin`` Protocol and the ``HookDecision`` union together define
+what every plugin implements.
+Concrete plugins (OAuth, HITL, observability hooks) live in sibling
+packages and import these types.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Optional, Protocol, Union, runtime_checkable
+
+if TYPE_CHECKING:
+    from diagrid.agent.core.plugins.context import LifecycleContext
+
+# dapr-agents owns the decision taxonomy so the two codebases share a single
+# definition. The local fallback below keeps the SPI importable on its own
+# until that module is available.
+if TYPE_CHECKING:
+    from dapr_agents.hooks import (
+        Deny,
+        HookDecision,
+        Mutate,
+        Proceed,
+        RequireApproval,
+        Skip,
+    )
+else:
+    try:
+        from dapr_agents.hooks import (
+            Deny,
+            HookDecision,
+            Mutate,
+            Proceed,
+            RequireApproval,
+            Skip,
+        )
+    except ImportError:
+        # Name-only placeholders; the real shapes arrive with the import above.
+        class Proceed:
+            pass
+
+        class Skip:
+            pass
+
+        class Mutate:
+            pass
+
+        class RequireApproval:
+            pass
+
+        class Deny:
+            pass
+
+        HookDecision = Union[Proceed, Skip, Mutate, RequireApproval, Deny]
+
+
+class LifecycleEvent(StrEnum):
+    """Lifecycle events fired by dapr-agents and python-ai's framework runners.
+
+    Plugins declare which events they care about through their
+    ``capabilities`` attribute.
+    """
+
+    BEFORE_AGENT_INVOKE = "BEFORE_AGENT_INVOKE"
+    AFTER_AGENT_INVOKE = "AFTER_AGENT_INVOKE"
+    BEFORE_LLM_CALL = "BEFORE_LLM_CALL"
+    AFTER_LLM_CALL = "AFTER_LLM_CALL"
+    BEFORE_TOOL_CALL = "BEFORE_TOOL_CALL"
+    AFTER_TOOL_CALL = "AFTER_TOOL_CALL"
+    # Derived from BEFORE_TOOL_CALL when the target resolves to an MCP server.
+    BEFORE_MCP_CALL = "BEFORE_MCP_CALL"
+    BEFORE_APPROVAL_DECISION = "BEFORE_APPROVAL_DECISION"
+
+
+@runtime_checkable
+class Plugin(Protocol):
+    """Protocol every plugin implements.
+
+    Plugins are composable units.
+    A ``PluginRegistry`` holds a chain of them and dispatches lifecycle
+    events in priority order.
+
+    Attributes:
+        name: Stable identifier used in audit events and debug logs.
+        priority: Lower runs first; ties break by registration order.
+            By convention security plugins (OAuth, HITL) use 10,
+            OBO-related plugins use 50, and the legacy hooks adapter uses 100.
+        capabilities: The set of events this plugin handles.
+            Events outside the set short-circuit before reaching
+            ``on_event``, which avoids a no-op call.
+        failure_mode: ``"closed"`` turns an exception into a ``Deny`` and
+            short-circuits the chain; ``"open"`` logs, emits a metric, and
+            proceeds. Security plugins must be ``"closed"``; observability
+            plugins may be ``"open"``.
+    """
+
+    name: str
+    priority: int
+    capabilities: frozenset[LifecycleEvent]
+    failure_mode: str
+
+    def configure(self, agent: Any) -> None:
+        """Initialize per-agent state.
+
+        Called once when the plugin is attached to an agent.
+        This is where clients are opened and sub-handlers are registered.
+        """
+        ...
+
+    async def on_event(self, ctx: "LifecycleContext") -> Optional[HookDecision]:
+        """Handle one of this plugin's ``capabilities`` events.
+
+        Return ``None`` or ``Proceed`` to continue the chain.
+        Return ``Skip``, ``Mutate``, ``RequireApproval``, or ``Deny`` to
+        alter the workflow following dapr-agents semantics.
+        """
+        ...
+
+
+__all__ = [
+    "Plugin",
+    "LifecycleEvent",
+    "HookDecision",
+    "Proceed",
+    "Skip",
+    "Mutate",
+    "RequireApproval",
+    "Deny",
+]

--- a/diagrid/agent/core/plugins/spi.py
+++ b/diagrid/agent/core/plugins/spi.py
@@ -19,7 +19,9 @@ if TYPE_CHECKING:
 
 # dapr-agents owns the decision taxonomy so the two codebases share a single
 # definition. The local fallback below keeps the SPI importable on its own
-# until that module is available.
+# until a dapr-agents release ships the ``hooks`` module. Catch only
+# ModuleNotFoundError so a genuine import error inside an existing module
+# surfaces instead of being masked by the fallback.
 if TYPE_CHECKING:
     from dapr_agents.hooks import (
         Deny,
@@ -39,7 +41,7 @@ else:
             RequireApproval,
             Skip,
         )
-    except ImportError:
+    except ModuleNotFoundError:
         # Name-only placeholders; the real shapes arrive with the import above.
         class Proceed:
             pass

--- a/tests/agent/core/plugins/__init__.py
+++ b/tests/agent/core/plugins/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) 2026-Present Diagrid Inc.
+# SPDX-License-Identifier: BUSL-1.1

--- a/tests/agent/core/plugins/test_scaffolding.py
+++ b/tests/agent/core/plugins/test_scaffolding.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2026-Present Diagrid Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+"""Smoke tests for the plugins module scaffolding.
+
+Behavioral tests for the registry land alongside its dispatch
+implementation.
+"""
+
+import pytest
+
+from diagrid.agent.core.plugins import (
+    Plugin,
+    LifecycleEvent,
+    HookDecision,
+    Proceed,
+    Skip,
+    Mutate,
+    RequireApproval,
+    Deny,
+    LifecycleContext,
+    CallerIdentity,
+    CallTarget,
+    PluginRegistry,
+)
+
+
+def test_public_api_imports():
+    """All advertised public names can be imported from the package."""
+    assert Plugin is not None
+    assert LifecycleEvent is not None
+    assert HookDecision is not None
+    for decision in (Proceed, Skip, Mutate, RequireApproval, Deny):
+        assert decision is not None
+
+
+def test_lifecycle_event_values():
+    """LifecycleEvent enum has the expected event names."""
+    expected = {
+        "BEFORE_AGENT_INVOKE",
+        "AFTER_AGENT_INVOKE",
+        "BEFORE_LLM_CALL",
+        "AFTER_LLM_CALL",
+        "BEFORE_TOOL_CALL",
+        "AFTER_TOOL_CALL",
+        "BEFORE_MCP_CALL",
+        "BEFORE_APPROVAL_DECISION",
+    }
+    assert {e.value for e in LifecycleEvent} == expected
+
+
+def test_plugin_protocol_runtime_checkable():
+    """A class implementing the full Plugin surface satisfies the Protocol."""
+
+    class FakePlugin:
+        name = "fake"
+        priority = 100
+        capabilities = frozenset({LifecycleEvent.BEFORE_TOOL_CALL})
+        failure_mode = "closed"
+
+        def configure(self, agent):
+            pass
+
+        async def on_event(self, ctx):
+            return Proceed()
+
+    assert isinstance(FakePlugin(), Plugin)
+
+
+def test_lifecycle_context_construction():
+    ctx = LifecycleContext(
+        event=LifecycleEvent.BEFORE_AGENT_INVOKE,
+        workflow_instance_id="wf-1",
+        agent_identity={"spiffe_id": "spiffe://...", "app_id": "agent-svc"},
+    )
+    assert ctx.event == LifecycleEvent.BEFORE_AGENT_INVOKE
+    assert ctx.caller is None
+    assert ctx.target is None
+    assert ctx.metadata == {}
+
+
+def test_caller_identity_construction():
+    caller = CallerIdentity(
+        subject="alice@acme.com",
+        tenant="acme",
+        scopes=frozenset({"agent.invoke"}),
+    )
+    assert caller.subject == "alice@acme.com"
+    assert caller.is_agent is False
+
+
+def test_call_target_construction():
+    target = CallTarget(kind="mcp", name="weather", source="mcp")
+    assert target.kind == "mcp"
+    assert target.audience is None
+    assert target.resource_indicators == frozenset()
+
+
+def test_plugin_registry_sorts_by_priority():
+    """Plugins are ordered by ascending priority, ties keep insertion order."""
+
+    class StubA:
+        name = "a"
+        priority = 50
+        capabilities = frozenset()
+        failure_mode = "open"
+
+        def configure(self, agent):
+            pass
+
+        async def on_event(self, ctx):
+            return None
+
+    class StubB:
+        name = "b"
+        priority = 10
+        capabilities = frozenset()
+        failure_mode = "closed"
+
+        def configure(self, agent):
+            pass
+
+        async def on_event(self, ctx):
+            return None
+
+    registry = PluginRegistry([StubA(), StubB()])
+    assert [p.name for p in registry._plugins] == ["b", "a"]
+
+
+def test_plugin_registry_dispatch_not_implemented_yet():
+    """The scaffold ships without dispatch; it raises NotImplementedError."""
+    registry = PluginRegistry()
+    with pytest.raises(NotImplementedError):
+        registry.dispatch("BEFORE_AGENT_INVOKE", {})


### PR DESCRIPTION
## What

Scaffolds a new `diagrid/agent/core/plugins/` package — the foundation for
the agent plugin system. This is structure and types only; no runtime
behavior is wired up yet.

- `spi.py` — `Plugin` Protocol, `LifecycleEvent` enum, and the
  `HookDecision` taxonomy (`Proceed`/`Skip`/`Mutate`/`RequireApproval`/`Deny`).
  The taxonomy is sourced from `dapr_agents.hooks` so both codebases share a
  single definition, with a name-only local fallback so the package imports
  on its own until that upstream module ships.
- `context.py` — `LifecycleContext`, `CallerIdentity`, and `CallTarget`
  dataclasses passed into `Plugin.on_event`.
- `registry.py` — `PluginRegistry` skeleton. Sorts plugins by ascending
  priority (registration order breaks ties); `attach`/`detach`/`dispatch`
  raise `NotImplementedError` pending the dispatch implementation.
- `__init__.py` — public API re-exports; `py.typed` marker, matching the
  convention of the sibling `workflow/` and `state/` packages.

## Why

Establishes the import surface and dataclass/Protocol shapes that the
downstream plugin work depends on (registry chain dispatch, the HooksPlugin
compat adapter, OAuth and HITL plugins, and framework-runner integration).
Landing the scaffold first lets that work build against a stable surface.

## Scope

- Type and Protocol definitions + registry skeleton only.
- `PluginRegistry.dispatch` is intentionally unimplemented.
- The `dapr_agents.hooks` fallback is temporary: once that upstream module
  is available, the `TYPE_CHECKING`/`try`/`except` block collapses to a plain
  import.


https://linear.app/diagrid/issue/AI-598/python-ai-scaffold-diagridagentcoreplugins-module